### PR TITLE
Update for Moya 9.0.0

### DIFF
--- a/Example/Example/ExampleAPI.swift
+++ b/Example/Example/ExampleAPI.swift
@@ -4,9 +4,7 @@ import Moya_Marshal
 import ReactiveSwift
 import Marshal
 
-let regularProvider = MoyaProvider<ExampleAPI>(stubClosure: MoyaProvider.immediatelyStub)
-let rcProvider = ReactiveSwiftMoyaProvider<ExampleAPI>(stubClosure: MoyaProvider.immediatelyStub)
-let rxProvider = RxMoyaProvider<ExampleAPI>(stubClosure: MoyaProvider.immediatelyStub)
+let provider = MoyaProvider<ExampleAPI>(stubClosure: MoyaProvider.immediatelyStub)
 
 enum ExampleAPI {
     case object
@@ -50,14 +48,11 @@ extension ExampleAPI: TargetType {
         return data
     }
 
-    var multipartBody: [MultipartFormData]? {
+    var task: Task {
+        return Task.requestPlain
+    }
+
+    var headers: [String : String]? {
         return nil
     }
-    var task: Task {
-        return Task.request
-    }
-    var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
-    
 }

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
         usingRxSwift()
     }
     func onlyMoya(){
-        regularProvider.request(ExampleAPI.object) { (result) -> () in
+        provider.request(ExampleAPI.object) { (result) -> () in
             switch result {
             case let .success(response):
                 do {
@@ -31,7 +31,7 @@ class ViewController: UIViewController {
     }
     
     func usingReactiveCocoa(){
-        rcProvider
+        provider.reactive
             .request(ExampleAPI.object)
             .map(to: User.self)
             .on(failed: { (error) -> () in
@@ -43,7 +43,7 @@ class ViewController: UIViewController {
     }
     
     func usingRxSwift(){
-        rxProvider
+        provider.rx
             .request(ExampleAPI.array)
             .mapArray(of: User.self)
             .subscribe(onNext: { (response) -> Void in

--- a/Moya-Marshal.podspec
+++ b/Moya-Marshal.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.description  = <<-EOS
   [Marshal](https://github.com/utahiosmac/Marshal) bindings for
   [Moya](https://github.com/Moya/Moya) for easier JSON serialization.
-  Includes [RxSwift](https://github.com/ReactiveX/RxSwift/) and 
+  Includes [RxSwift](https://github.com/ReactiveX/RxSwift/) and
   [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa/) bindings as well.
   Instructions on how to use it are in
   [the README](https://github.com/JARMourato/Moya-Marshal).
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Core" do |ss|
     ss.source_files  = "Sources/*.swift"
-    ss.dependency "Moya", "~> 8.0.0"
+    ss.dependency "Moya", "~> 9.0.0"
     ss.dependency "Marshal", "~> 1.2.0"
     ss.framework  = "Foundation"
   end

--- a/Sources/ReactiveCocoa/SignalProducer+Marshal.swift
+++ b/Sources/ReactiveCocoa/SignalProducer+Marshal.swift
@@ -33,7 +33,7 @@ extension SignalProducerProtocol where Value == Moya.Response, Error == MoyaErro
     /// Maps data received from the signal into an object which implements the Unmarshaling protocol.
     /// If the conversion fails, the signal errors.
     public func map<T: Unmarshaling>(to type: T.Type) -> SignalProducer<T, MoyaError> {
-        return producer.flatMap(.latest) { response -> SignalProducer<T, Moya.Error> in
+        return producer.flatMap(.latest) { response -> SignalProducer<T, MoyaError> in
             return unwrapThrowable { try response.map(to: type) }
         }
     }
@@ -41,7 +41,7 @@ extension SignalProducerProtocol where Value == Moya.Response, Error == MoyaErro
     /// Maps data received from the signal into an array of objects which implement the Unmarshaling protocol.
     /// If the conversion fails, the signal errors.
     public func map<T: Unmarshaling>(of type: T.Type) -> SignalProducer<[T], MoyaError> {
-        return producer.flatMap(.latest) { response -> SignalProducer<[T], Moya.Error> in
+        return producer.flatMap(.latest) { response -> SignalProducer<[T], MoyaError> in
             return unwrapThrowable { try response.mapArray(of: type) }
         }
     }

--- a/Sources/RxSwift/Observable+Marshal.swift
+++ b/Sources/RxSwift/Observable+Marshal.swift
@@ -28,13 +28,13 @@ import Moya
 import Marshal
 
 /// Extension for processing Responses into Mappable objects through Marshal
-public extension ObservableType where E == Response {
     
+public extension Single where Element == Response {
     /// Maps data received from the signal into an object
     /// which implements the Unmarshaling protocol and returns the result back
     /// If the conversion fails, the signal errors.
     public func map<T: Unmarshaling>(to type: T.Type) -> Observable<T> {
-        return flatMap { response -> Observable<T> in
+        return asObservable().flatMap { response -> Observable<T> in
             return Observable.just(try response.map(to: T.self))
         }
     }
@@ -43,7 +43,7 @@ public extension ObservableType where E == Response {
     /// which implement the Unmarshaling protocol and returns the result back
     /// If the conversion fails, the signal errors.
     public func mapArray<T: Unmarshaling>(of type: T.Type) -> Observable<[T]> {
-        return flatMap { response -> Observable<[T]> in
+        return asObservable().flatMap { response -> Observable<[T]> in
             return Observable.just(try response.mapArray(of: T.self))
         }
 


### PR DESCRIPTION
This Pull requests adapts to changes made in the new Moya update.

Specifically, it
- updates the Moya dependency `.podspec` file to Version `9.0.0`
- migrates instances of `Moya.Error` to `MoyaError`
- RxSwift requests now are `Single` instead of `Observable`
- adapts the Example project to the changes specified in [the migration guide](https://github.com/Moya/Moya/blob/master/docs/MigrationGuides.md):
    - Removes deprecated usage of `RxMoyaProvider` and `ReactiveMoyaProvider`
    - Adapts to the new `TargetType` conformance requirements